### PR TITLE
ICS-1476 Handle SCOM alerts with descriptions containing single quotes.

### DIFF
--- a/scom/opsgenie.ps1
+++ b/scom/opsgenie.ps1
@@ -66,10 +66,14 @@
 
 )
 
+for ($i=0; $i -lt $args.Count; $i++){
+       [String]$restOfAlertDesc += $($args[$i])
+}
+
 $params = @{
 alertId=$AlertID;
 alertName=$AlertName;
-alertDescription=$AlertDesc;
+alertDescription=$AlertDesc + $restOfAlertDesc;
 resolutionState=$ResolutionState;
 resolutionStateLastModified=$ResolutionStateLastModified;
 priority=$Priority;


### PR DESCRIPTION
It'll use the built-in $args variable to get the rest of the alert description.