### PR TITLE
Add Icinga2 unack ability

### DIFF
--- a/icinga2/common/opsgenie-integration.conf.part
+++ b/icinga2/common/opsgenie-integration.conf.part
@@ -37,6 +37,7 @@ actions.AddNote.script=icingaActionExecutor.groovy
 actions.TakeOwnership.script=icingaActionExecutor.groovy
 actions.AssignOwnership.script=icingaActionExecutor.groovy
 actions.Create.script=icingaActionExecutor.groovy
+actions.UnAcknowledge.script=icingaActionExecutor.groovy
 
 #You can configure more than one Icinga Server like the following (used in marid)
 #In order to use feature you should also set icinga_server:server1

--- a/icinga2/marid/scripts/icingaActionExecutor.groovy
+++ b/icinga2/marid/scripts/icingaActionExecutor.groovy
@@ -77,6 +77,8 @@ if (alertFromOpsgenie.size() > 0) {
                     }
                 }
             }
+        } else if (action == "UnAcknowledge") {
+            urlPath = "/v1/actions/remove-acknowledgement"
         } else if (action == "TakeOwnership") {
             urlPath = "/v1/actions/add-comment"
             contentMap.put("comment", String.valueOf("alert ownership taken by ${alert.username}"))


### PR DESCRIPTION
Currently it is impossible to relay an unack in the alerts dashboard through to Icinga2. This commit enables the ability to relay unacks through to Icinga2.