### PR TITLE
Add mapping from Zabbix severities to OpsGenie priorities

### DIFF
--- a/zabbix/common/opsgenie-integration.conf.part
+++ b/zabbix/common/opsgenie-integration.conf.part
@@ -7,6 +7,13 @@ logPath=/var/log/opsgenie/zabbix2opsgenie.log
 #responders=<comma_separated_list_of_responders>
 #tags=<comma_separated_list_of_tags>
 
+############################ Mapping Zabbix Severity to OpsGenie Priority ###########################
+zabbix2opsgenie.severity.information=P5
+zabbix2opsgenie.severity.warning=P4
+zabbix2opsgenie.severity.average=P3
+zabbix2opsgenie.severity.high=P2
+zabbix2opsgenie.severity.disaster=P1
+
 ####################################### PROXY CONFIGURATION FOR ZABBIX ############################################
 zabbix2opsgenie.http.proxy.enabled=false
 zabbix2opsgenie.http.proxy.port=11111

--- a/zabbix/zabbix/zabbix2opsgenie.go
+++ b/zabbix/zabbix/zabbix2opsgenie.go
@@ -31,7 +31,12 @@ var configParameters = map[string]string{"apiKey": API_KEY,
 	"zabbix2opsgenie.http.proxy.host": "localhost",
 	"zabbix2opsgenie.http.proxy.protocol":"http",
 	"zabbix2opsgenie.http.proxy.username": "",
-	"zabbix2opsgenie.http.proxy.password": ""}
+	"zabbix2opsgenie.http.proxy.password": "",
+	"zabbix2opsgenie.severity.information": "P5",
+	"zabbix2opsgenie.severity.warning": "P4",
+	"zabbix2opsgenie.severity.average": "P3",
+	"zabbix2opsgenie.severity.high": "P2",
+	"zabbix2opsgenie.severity.disaster": "P1"}
 var configPath = "/etc/opsgenie/conf/opsgenie-integration.conf"
 var levels = map [string]log.Level{"info":log.Info,"debug":log.Debug,"warning":log.Warning,"error":log.Error}
 var logger log.Logger
@@ -283,6 +288,7 @@ func parseFlags()map[string]string{
 	parameters["itemValue"] = *itemValue
 	parameters["eventId"] = *eventId
 	parameters["recoveryEventStatus"] = *recoveryEventStatus
+	parameters["mappedPriority"] = configParameters["zabbix2opsgenie.severity."+strings.ToLower(*triggerSeverity)]
 
 	if *apiKey != ""{
 		configParameters["apiKey"] = *apiKey


### PR DESCRIPTION
To use the mapped priorities, use the combination "Custom Value
to Opsgenie Priority" with the field "{{_payload.mappedPriority}}"
for Priority in your Zabbix Integration.

Fixes #29