### PR TITLE
Updated zabbix2opsgenie.go to allow for ack

### DIFF
--- a/zabbix/zabbix/zabbix2opsgenie.go
+++ b/zabbix/zabbix/zabbix2opsgenie.go
@@ -264,7 +264,8 @@ func parseFlags()map[string]string{
 	tags := flag.String ("tags","","tags")
 	responders := flag.String ("responders","","responders")
 	logPath := flag.String("logPath", "", "LOGPATH")
-
+        eventAck := flag.string("eventAck", "", "EVENTACK")
+	
 	flag.Parse()
 
 	parameters["triggerName"] = *triggerName
@@ -283,6 +284,7 @@ func parseFlags()map[string]string{
 	parameters["itemValue"] = *itemValue
 	parameters["eventId"] = *eventId
 	parameters["recoveryEventStatus"] = *recoveryEventStatus
+        parameters["eventAck"] = *eventAck
 
 	if *apiKey != ""{
 		configParameters["apiKey"] = *apiKey


### PR DESCRIPTION
Updated zabbix2opsgenie.go to allow for filtering on acknowledged yes or no.

Important to add:
/etc/opsgenie/zabbix2opsgenie -triggerName='{TRIGGER.NAME}' -triggerId='{TRIGGER.ID}' -triggerStatus='{TRIGGER.STATUS}' -triggerSeverity='{TRIGGER.SEVERITY}' -triggerDescription='{TRIGGER.DESCRIPTION}' -triggerUrl='{TRIGGER.URL}' -triggerValue='{TRIGGER.VALUE}' -triggerHostGroupName='{TRIGGER.HOSTGROUP.NAME}' -hostName='{HOST.NAME}' -ipAddress='{IPADDRESS}' -eventId='{EVENT.ID}' -date='{DATE}' -time='{TIME}' -itemKey='{ITEM.KEY}' -itemValue='{ITEM.VALUE}' -recoveryEventStatus='{EVENT.RECOVERY.STATUS} -eventAck='{EVENT.ACK.STATUS}’

To Zabbix action 'Update Operation'

OpsGenie should filters should allow for filtering on this as well to make this change possible.